### PR TITLE
1 page only bug fixed, added progress counter

### DIFF
--- a/artnet_scraper.py
+++ b/artnet_scraper.py
@@ -13,61 +13,48 @@ def storeImg(url: str, output_path: str):
     Opens the image and store in the output folder.
     """
     req = Request(url, headers={'User-Agent': 'Mozilla/6.0'})
-    err_cnt = 0
-    while(err_cnt < 20):
-        try:
-            img = Image.open(urlopen(req))
-            break
-        except:
-            err_cnt+=1 
-            time.sleep(1)
-
-    if err_cnt < 20:
+    try:
+        img = Image.open(urlopen(req))
         imgName = 'img_'+datetime.now().strftime("%d%m%Y_%H%M%S%f")+'.jpg'
-        try:
-            img.save('{}'.format(output_path+imgName))
-        except:
-            print('Error while saving {} image.'.format(imgName))
-    else:
-        print('Couldn\'t retrieve image on {}'.format(url))
+        img.save('{}'.format(output_path+imgName))
+    except:
+        time.sleep(0.1)
 
 def FindStoreImgUrl(artwork_links: list, output_path: str):
     """
     Finds the .jpg url in an artwork page and call the storeImg function.
     """
-    for url in artwork_links:
-        err_cnt = 0
-        while err_cnt < 20:
-            try:
-                result = requests.get(url)
-                soup = BeautifulSoup(result.content, 'html.parser')
-                imgArea = soup.find("div", {"id": "imgArea"})
-                imgUrl = imgArea.find("img")['src']
-                break
-
-            except:
-                err_cnt+=1
-                time.sleep(1)
-
-        if err_cnt < 20:
+    total = len(artwork_links)
+    for i, url in enumerate(artwork_links):
+        try:
+            result = requests.get(url)
+            soup = BeautifulSoup(result.content, 'html.parser')
+            imgArea = soup.find("div", {"id": "imgArea"})
+            imgUrl = imgArea.find("img")['src']
             baseUrl = '/'.join(imgUrl.split('/')[:6])
             imgUrl = '/'.join(imgUrl.split('/')[6:])
-
             storeImg(baseUrl + '/' + quote(imgUrl), output_path)
-        else:
-            print('Couldn\'t get image from {}'.format(url))
+        except:
+            time.sleep(0.1)
+        	
+        percent = 100.0*i/total
+        sys.stdout.write('\r')
+        sys.stdout.write("Completed: [{:{}}] {:>3}%".format('='*int(percent/(100.0/50)+5), 50, int(percent)+5)) # this needs fixing in future
+        sys.stdout.flush()
             
 def FindStoreImg(artist: str, output_path: str):
     """
     Main loop. It scraps an artnet artist's page to find all of his artworks' pages.
     """
-    curr_page = 1
+    curr_page = 0
     last_page = False
 
     fail_cnt = 0
     cnt = 0
 
-    while (not last_page) & (fail_cnt < 20):
+    while (not last_page):
+        curr_page+=1
+        print('Scraping images from page: ' + str(curr_page))
         url = 'https://www.artnet.com/artistes/'+artist+'/'+str(curr_page)
         artwork_links_arr = []
 
@@ -89,7 +76,7 @@ def FindStoreImg(artist: str, output_path: str):
             #soup.findAll('a',  attrs={'href': re.compile("^/artistes/{}.+[a-zA-Z0-9-]+/.+[a-z]+.+[0-9]+".format(artist.split('-')[0]))})
             for link in artwork_links:
                 link = link.get('href')
-                print(link)
+                #print(link)
                 # Links appear twice in the source ode
                 if link != previous_link:
                     artwork_links_arr.append('https://www.artnet.com'+link)
@@ -99,40 +86,25 @@ def FindStoreImg(artist: str, output_path: str):
 
             
             FindStoreImgUrl(artwork_links_arr, output_path)
-
-            print('{} images scrapped so far...'.format(cnt), end = '\r')
-
-            # Find the next page to scrap
-            index = 0 if curr_page < 3 else 1
-            next_link = curr_page
-            while int(next_link) <= curr_page:
-                try:
-                    next_page_links = soup.findAll('a',  attrs={'href': re.compile("^/artistes/{}/[0-9]+$".format(artist))})
-                    next_link = next_page_links[index].get('href')
-                    next_link = next_link.split('/')[-1]
-                    index+=1
-                except:
-                    last_page = True
-                    next_link = curr_page+1
-
-            curr_page = int(next_link)
+            print('')
+            print('{} images scraped so far.'.format(cnt))
 
     if fail_cnt >= 20:
-        print('Error while accessing the web page. Stopped at {}th iteration.'.format(curr_page))
+        print('\nError while accessing the web page. Stopped at {}th iteration.'.format(curr_page))
     
-    print('{} images saved in {}.'.format(cnt, output))
+    print('\n{} images saved.'.format(cnt))
 
 
 def main(argv):
     try:
         opts, args = getopt.getopt(argv, "hn:f:", ["name=", "img_folder="])
     except getopt.GetoptError:
-        print('usage: artnet_scrapper.py -n <artist-name> -f <image folder>')
+        print('usage: artnet_scraper.py -n <artist-name> -f <image folder>')
         sys.exit(2)
     
     for opt, arg in opts:
         if opt == '-h':
-            print('usage: artnet_scrapper.py -n <artist-name> -f <image folder>\nExample: artnet_scrapper.py -n gustave-klimt -f img/')
+            print('usage: artnet_scraper.py -n <artist-name> -f <image folder>\nExample: artnet_scraper.py -n gustave-klimt -f img/')
             sys.exit()
         
         elif opt in ('-n', '--name'):
@@ -144,7 +116,7 @@ def main(argv):
     try:
         print('Searching for {} art pieces on artnet. The images will be stored in {} folder.'.format(artist, img_folder))
     except:
-        print('usage: artnet_scrapper.py -n <artist-name> -f <image folder>\nExample: artnet_scrapper.py -n gustave-klimt -f img/')
+        print('usage: artnet_scraper.py -n <artist-name> -f <image folder>\nExample: artnet_scraper.py -n gustave-klimt -f img/')
         sys.exit(2)
 
     FindStoreImg(artist, img_folder)


### PR DESCRIPTION
There's a bug in the original code that causes the scraper to only download the first page, I have fixed this

The code also runs a lot faster now, since before a failure would cause it to hang for 20 seconds (sleep for 1 sec every fail up to 20). Failures are just skipped. 

Added a progress bar for feedback during each page scrape rather than just printing all the links

no new requirements are needed